### PR TITLE
Add support for attachments

### DIFF
--- a/postmark.php
+++ b/postmark.php
@@ -4,7 +4,7 @@ Plugin Name: Postmark Approved WordPress Plugin
 Plugin URI: http://www.andydev.co.uk
 Description: Overwrites wp_mail to send emails through Postmark.
 Author: Andrew Yates
-Version: 1.5
+Version: 1.6
 Author URI: http://www.andydev.co.uk
 Created: 2011-07-05
 Modified: 2012-09-10
@@ -36,42 +36,54 @@ function pm_admin_menu() {
 }
 
 function pm_admin_action_links($links, $file) {
-	static $pm_plugin;
-	if (!$pm_plugin) {
-		$pm_plugin = plugin_basename(__FILE__);
-	}
-	if ($file == $pm_plugin) {
-		$settings_link = '<a href="' . admin_url( 'options-general.php' ) . '?page=pm_admin">Settings</a>';
-		array_unshift($links, $settings_link);
-	}
-	return $links;
+    static $pm_plugin;
+    if (!$pm_plugin) {
+        $pm_plugin = plugin_basename(__FILE__);
+    }
+    if ($file == $pm_plugin) {
+        $settings_link = '<a href="options-general.php?page=pm_admin">Settings</a>';
+        array_unshift($links, $settings_link);
+    }
+    return $links;
 }
 
 add_filter('plugin_action_links', 'pm_admin_action_links', 10, 2);
 
 
 function pm_admin_options() {
-	if( isset($_POST['submit']) && !empty($_POST['submit']) && wp_verify_nonce( $_POST['pm_save_nonce'], 'save postmark settings' ) ) {
-
-		if( isset($_POST['pm_enabled']) && $_POST['pm_enabled'] == 1 ) {
+	if($_POST['submit']) {
+		$pm_enabled = $_POST['pm_enabled'];
+		if($pm_enabled):
 			$pm_enabled = 1;
-		} else {
+		else:
 			$pm_enabled = 0;
-		}
+		endif;
 
 		$api_key = $_POST['pm_api_key'];
 		$sender_email = $_POST['pm_sender_address'];
 
-		if( isset($_POST['pm_forcehtml']) && $_POST['pm_forcehtml'] == 1 ) {
+		$pm_forcehtml = $_POST['pm_forcehtml'];
+		if($pm_forcehtml):
 			$pm_forcehtml = 1;
-		} else {
+		else:
 			$pm_forcehtml = 0;
-		}
+		endif;
 
-		if( isset($_POST['pm_poweredby']) && $_POST['pm_poweredby'] == 1 ) {
+		$pm_poweredby = $_POST['pm_poweredby'];
+		if($pm_poweredby):
 			$pm_poweredby = 1;
-		} else {
+		else:
 			$pm_poweredby = 0;
+		endif;
+
+		$pm_trackopens = $_POST['pm_trackopens'];
+		if($pm_trackopens){
+			$pm_trackopens = 1;
+			$pm_forcehtml = 1;
+		}
+		else
+		{
+			$pm_trackopens = 0;
 		}
 
 		update_option('postmark_enabled', $pm_enabled);
@@ -79,66 +91,71 @@ function pm_admin_options() {
 		update_option('postmark_sender_address', $sender_email);
 		update_option('postmark_force_html', $pm_forcehtml);
 		update_option('postmark_poweredby', $pm_poweredby);
+		update_option('postmark_trackopens', $pm_trackopens);
 
 		$msg_updated = "Postmark settings have been saved.";
 	}
 	?>
 
 	<script type="text/javascript" >
-		jQuery(document).ready(function($) {
+	jQuery(document).ready(function($) {
 
-			$("#test-form").submit(function(e){
-				e.preventDefault();
-				var $this = $(this);
-				var send_to = $('#pm_test_address').val();
+		$("#test-form").submit(function(e){
+			e.preventDefault();
+			var $this = $(this);
+			var send_to = $('#pm_test_address').val();
 
-				$("#test-form .button-primary").val("Sending…");
-				$.post(ajaxurl, {email: send_to, action:$this.attr("action")}, function(data){
-					$("#test-form .button-primary").val(data);
-				});
+			$("#test-form .button-primary").val("Sending…");
+			$.post(ajaxurl, {email: send_to, action:$this.attr("action")}, function(data){
+				$("#test-form .button-primary").val(data);
 			});
-
 		});
+
+	});
 	</script>
 
 	<div class="wrap">
 
-		<?php if( isset($msg_updated) && $msg_updated != '' ) : ?><div class="updated"><p><?php echo $msg_updated; ?></p></div><?php endif; ?>
+		<?php if($msg_updated): ?><div class="updated"><p><?php echo $msg_updated; ?></p></div><?php endif; ?>
+		<?php if($msg_error): ?><div class="error"><p><?php echo $msg_error; ?></p></div><?php endif; ?>
 
 		<div id="icon-tools" class="icon32"></div>
 		<h2><img src="<?php echo WP_PLUGIN_URL.'/'.str_replace(basename( __FILE__),"",plugin_basename(__FILE__)) ?>images/PM-Logo.jpg" /></h2>
-		<h3>What is Postmark?</h3>
+    <h3>What is Postmark?</h3>
 		<p>This Postmark Approved plugin enables WordPress blogs of any size to deliver and track WordPress notification emails reliably, with minimal setup time and zero maintenance. </p>
 		<p>If you don't already have a free Postmark account, <a href="https://postmarkapp.com/sign_up">you can get one in minutes</a>. Every account comes with 1000 free sends.</p>
 
 		<br />
 
 		<h3>Your Postmark Settings</h3>
-		<form method="post" action="<?php echo admin_url( 'options-general.php' ); ?>?page=pm_admin">
-			<?php wp_nonce_field('save postmark settings','pm_save_nonce'); ?>
+		<form method="post" action="options-general.php?page=pm_admin">
 			<table class="form-table">
-				<tbody>
+			<tbody>
 				<tr>
 					<th><label for="pm_enabled">Send using Postmark</label></th>
-					<td><input name="pm_enabled" id="pm_enabled" type="checkbox" value="1"<?php if(get_option('postmark_enabled') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Sends emails sent using wp_mail via Postmark.</span></td>
+					<td><input name="pm_enabled" id="" type="checkbox" value="1"<?php if(get_option('postmark_enabled') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Sends emails sent using wp_mail via Postmark.</span></td>
 				</tr>
 				<tr>
 					<th><label for="pm_api_key">Postmark API Key</label></th>
-					<td><input name="pm_api_key" id="pm_api_key" type="text" value="<?php echo get_option('postmark_api_key'); ?>" class="regular-text"/> <br/><span style="font-size:11px;">Your API key is available in the <strong>credentials</strong> screen of your Postmark server. <a href="https://postmarkapp.com/servers/">Create a new server in Postmark</a>.</span></td>
+					<td><input name="pm_api_key" id="" type="text" value="<?php echo get_option('postmark_api_key'); ?>" class="regular-text"/> <br/><span style="font-size:11px;">Your API key is available in the <strong>credentials</strong> screen of your Postmark server. <a href="https://postmarkapp.com/servers/">Create a new server in Postmark</a>.</span></td>
 				</tr>
 				<tr>
 					<th><label for="pm_sender_address">Sender Email Address</label></th>
-					<td><input name="pm_sender_address" id="pm_sender_address" type="text" value="<?php echo get_option('postmark_sender_address'); ?>" class="regular-text"/> <br/><span style="font-size:11px;">This email needs to be one of your <strong>verified sender signatures</strong>. <br/>It will appear as the "from" email on all outbound messages. <a href="https://postmarkapp.com/signatures">Set one up in Postmark</a>.</span></td>
+					<td><input name="pm_sender_address" id="" type="text" value="<?php echo get_option('postmark_sender_address'); ?>" class="regular-text"/> <br/><span style="font-size:11px;">This email needs to be one of your <strong>verified sender signatures</strong>. <br/>It will appear as the "from" email on all outbound messages. <a href="https://postmarkapp.com/signatures">Set one up in Postmark</a>.</span></td>
 				</tr>
 				<tr>
 					<th><label for="pm_forcehtml">Force HTML</label></th>
-					<td><input name="pm_forcehtml" id="pm_forcehtml" type="checkbox" value="1"<?php if(get_option('postmark_force_html') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Force all emails to be sent as HTML.</span></td>
+					<td><input name="pm_forcehtml" id="" type="checkbox" value="1"<?php if(get_option('postmark_force_html') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Force all emails to be sent as HTML.</span></td>
+				</tr>
+				<tr>
+					<th><label for="pm_trackopens">Track Opens</label></th>
+					<td><input name="pm_trackopens" id="" type="checkbox" value="1"<?php if(get_option('postmark_trackopens') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Use Postmark's Open Tracking feature to capture open events. (Forces Html option to be turned on)</span></td>
 				</tr>
 				<tr>
 					<th><label for="pm_poweredby">Support Postmark</label></th>
-					<td><input name="pm_poweredby" id="pm_poweredby" type="checkbox" value="1"<?php if(get_option('postmark_poweredby') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Adds a credit to Postmark at the bottom of emails.</span></td>
+					<td><input name="pm_poweredby" id="" type="checkbox" value="1"<?php if(get_option('postmark_poweredby') == 1): echo ' checked="checked"'; endif; ?>/> <span style="font-size:11px;">Adds a credit to Postmark at the bottom of emails.</span></td>
 				</tr>
-				</tbody>
+			</tbody>
 			</table>
 			<div class="submit">
 				<input type="submit" name="submit" value="Save" class="button-primary" />
@@ -148,14 +165,14 @@ function pm_admin_options() {
 		<br />
 
 		<h3>Test Postmark Sending</h3>
-		<form method="post" id="test-form" action="">
+		<form method="post" id="test-form" action="pm_admin_test">
 			<table class="form-table">
-				<tbody>
+			<tbody>
 				<tr>
 					<th><label for="pm_test_address">Send a Test Email To</label></th>
 					<td> <input name="pm_test_address" id="pm_test_address" type="text" value="<?php echo get_option('postmark_sender_address'); ?>" class="regular-text"/></td>
 				</tr>
-				</tbody>
+			</tbody>
 			</table>
 			<div class="submit">
 				<input type="submit" name="submit" value="Send Test Email" class="button-primary" />
@@ -172,24 +189,24 @@ function pm_admin_options() {
 add_action('wp_ajax_pm_admin_test', 'pm_admin_test_ajax');
 function pm_admin_test_ajax() {
 	$response = pm_send_test();
-	wp_send_json($response);
+
+	echo $response;
+
+	die();
 }
 
 // End Admin Functionality
-
-
-
 
 // Override wp_mail() if postmark enabled
 if(get_option('postmark_enabled') == 1){
 	if (!function_exists("wp_mail")){
 		function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()) {
-
+            
 			// Define Headers
 			$postmark_headers = array(
 				'Accept' => 'application/json',
 				'Content-Type' => 'application/json',
-				'X-Postmark-Server-Token' => get_option('postmark_api_key')
+		        'X-Postmark-Server-Token' => get_option('postmark_api_key')
 			);
 
 			// If "Support Postmark" is on
@@ -199,6 +216,19 @@ if(get_option('postmark_enabled') == 1){
 					$message .= "\n\nPostmark solves your WordPress email problems. Send transactional email confidently using http://postmarkapp.com";
 				}
 			}
+            
+            // Get attachment data
+            if(!is_array($attachments))
+                $attachments = explode("\n", $attachments);
+            $attach = array();
+            foreach ($attachments as $a) {
+                $filetype = wp_check_filetype($a);
+                $attach[] = array(
+                    'Name' => basename($a),
+                    'Content' => base64_encode(@file_get_contents($a)),
+                    'ContentType' => $filetype['type']
+                );
+            }
 
 			// Send Email
 			if(!is_array($to)){
@@ -212,20 +242,24 @@ if(get_option('postmark_enabled') == 1){
 				$email = array();
 				$email['To'] = $recipient;
 				$email['From'] = get_option('postmark_sender_address');
-				$email['Subject'] = $subject;
-				$email['TextBody'] = $message;
+		    	$email['Subject'] = $subject;
+		    	$email['TextBody'] = $message;
+                $email['Attachments'] = $attach;
 
-				if(strpos($headers, "text/html" ) !== false || get_option('postmark_force_html') == 1){
-					$email['HtmlBody'] = $message;
-				}
+		    	if(strpos($headers, "text/html" ) || get_option('postmark_force_html') == 1){
+			    	$email['HtmlBody'] = $message;
+		    	}
 
-				$response = pm_send_mail($postmark_headers, $email);
+		    	if(get_option('postmark_trackopens') == 1){
+		    		$email['TrackOpens'] = "true";
+		    	}
+
+        		$response = pm_send_mail($postmark_headers, $email);
 			}
-			return ( isset($response) ) ? $response : '';
+			return $response;
 		}
 	}
 }
-
 
 function pm_send_test(){
 	$email_address = $_POST['email'];
@@ -234,7 +268,7 @@ function pm_send_test(){
 	$postmark_headers = array(
 		'Accept' => 'application/json',
 		'Content-Type' => 'application/json',
-		'X-Postmark-Server-Token' => get_option('postmark_api_key')
+        'X-Postmark-Server-Token' => get_option('postmark_api_key')
 	);
 
 	$message = 'This is a test email sent via Postmark from '.get_bloginfo('name').'.';
@@ -244,26 +278,31 @@ function pm_send_test(){
 		$message .= "\n\nPostmark solves your WordPress email problems. Send transactional email confidently using http://postmarkapp.com";
 		$html_message .= '<br /><br />Postmark solves your WordPress email problems. Send transactional email confidently using <a href="http://postmarkapp.com">Postmark</a>.';
 	}
-
+	
 	$email = array();
 	$email['To'] = $email_address;
 	$email['From'] = get_option('postmark_sender_address');
-	$email['Subject'] = get_bloginfo('name').' Postmark Test';
-	$email['TextBody'] = $message;
-
-	if(get_option('postmark_force_html') == 1){
-		$email['HtmlBody'] = $html_message;
+    $email['Subject'] = get_bloginfo('name').' Postmark Test';
+    $email['TextBody'] = $message;
+    
+    if(get_option('postmark_force_html') == 1){
+    	$email['HtmlBody'] = $html_message;
 	}
 
-	$response = pm_send_mail($postmark_headers, $email);
-
-	if ($response === false){
-		return "Test Failed with Error";
-	} else {
-		return "Test Sent";
+	if(get_option('postmark_trackopens') == 1){
+		$email['TrackOpens'] = "true";
 	}
+
+    $response = pm_send_mail($postmark_headers, $email);
+
+    if ($response === false){
+    	return "Test Failed with Error ".curl_error($curl);
+    } else {
+    	return "Test Sent";
+   	}
+
+    die();
 }
-
 
 function pm_send_mail($headers, $email){
 	$args = array(


### PR DESCRIPTION
I've added the support to allow sending of attachments to the plugin.
The attachments parameter works the same way as the original wp_mail.
"Files to attach: a single filename, an array of filenames, or a newline-delimited string list of multiple filenames."
